### PR TITLE
Feat/areas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@testing-library/react": "^13.4.0",
                 "@testing-library/user-event": "^13.5.0",
                 "@types/jest": "^27.5.2",
+                "@types/leaflet-draw": "^1.0.11",
                 "@types/node": "^16.18.62",
                 "@types/react": "^18.2.37",
                 "@types/react-dom": "^18.2.15",
@@ -20,6 +21,7 @@
                 "axios": "^1.6.2",
                 "json-server": "^0.17.4",
                 "leaflet": "^1.9.4",
+                "leaflet-draw": "^1.0.4",
                 "postcss": "^8.4.31",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -3707,8 +3709,7 @@
         "node_modules/@types/geojson": {
             "version": "7946.0.13",
             "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.13.tgz",
-            "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ==",
-            "dev": true
+            "integrity": "sha512-bmrNrgKMOhM3WsafmbGmC+6dsF2Z308vLFsQ3a/bT8X8Sv5clVYpPars/UPq+sAaJP+5OoLAYgwbkS5QEJdLUQ=="
         },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.9",
@@ -3789,9 +3790,16 @@
             "version": "1.9.8",
             "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.8.tgz",
             "integrity": "sha512-EXdsL4EhoUtGm2GC2ZYtXn+Fzc6pluVgagvo2VC1RHWToLGlTRwVYoDpqS/7QXa01rmDyBjJk3Catpf60VMkwg==",
-            "dev": true,
             "dependencies": {
                 "@types/geojson": "*"
+            }
+        },
+        "node_modules/@types/leaflet-draw": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@types/leaflet-draw/-/leaflet-draw-1.0.11.tgz",
+            "integrity": "sha512-dyedtNm3aSmnpi6FM6VSl28cQuvP+MD7pgpXyO3Q1ZOCvrJKmzaDq0P3YZTnnBs61fQCKSnNYmbvCkDgFT9FHQ==",
+            "dependencies": {
+                "@types/leaflet": "*"
             }
         },
         "node_modules/@types/mime": {
@@ -10733,6 +10741,11 @@
             "version": "1.9.4",
             "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
             "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
+        },
+        "node_modules/leaflet-draw": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
+            "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ=="
         },
         "node_modules/leven": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
+        "@types/leaflet-draw": "^1.0.11",
         "@types/node": "^16.18.62",
         "@types/react": "^18.2.37",
         "@types/react-dom": "^18.2.15",

--- a/src/components/molecules/AddAreaForm.tsx
+++ b/src/components/molecules/AddAreaForm.tsx
@@ -1,0 +1,100 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { addAreaOfInterest } from '../../redux/slices/areasOfInterest';
+import { Button, Input } from '../atoms';
+import axios from 'axios';
+
+const AddPointForm: React.FC = () => {
+    const dispatch = useDispatch();
+    const selectedAreaOfInterest = useSelector((state: any) =>
+        state.areasOfInterest ? state.areasOfInterest.selectedAreaOfInterest || {} : {},
+    );
+
+    const [localDescription, setLocalDescription] = useState('');
+
+    const [localLatitudeTop, setLocalLatitudeTop] = useState(
+        selectedAreaOfInterest?.topLeft?.latitude?.toString() || '',
+    );
+    const [localLongitudeLeft, setLocalLongitudeLeft] = useState(
+        selectedAreaOfInterest?.topLeft?.longitude?.toString() || '',
+    );
+    const [localLatitudeBottom, setLocalLatitudeBottom] = useState(
+        selectedAreaOfInterest?.bottomRight?.latitude?.toString() || '',
+    );
+    const [localLongitudeRight, setLocalLongitudeRight] = useState(
+        selectedAreaOfInterest?.bottomRight?.longitude?.toString() || '',
+    );
+
+    useEffect(() => {
+        if (selectedAreaOfInterest?.topLeft && selectedAreaOfInterest?.bottomRight) {
+            setLocalLatitudeTop(selectedAreaOfInterest.topLeft.latitude.toString());
+            setLocalLongitudeLeft(selectedAreaOfInterest.topLeft.longitude.toString());
+            setLocalLatitudeBottom(selectedAreaOfInterest.bottomRight.latitude.toString());
+            setLocalLongitudeRight(selectedAreaOfInterest.bottomRight.longitude.toString());
+        }
+    }, [selectedAreaOfInterest]);
+
+    const handleAddAreaOfInterest = async () => {
+        if (
+            localLatitudeTop.trim() !== '' &&
+            localLongitudeLeft.trim() !== '' &&
+            localLatitudeBottom.trim() !== '' &&
+            localLongitudeRight.trim() !== ''
+        ) {
+            const newAreaOfInterest = {
+                id: parseInt(Date.now().toString() + Math.floor(Math.random() * 100).toString()),
+                description: localDescription,
+                topLeft: {
+                    latitude: parseFloat(localLatitudeTop),
+                    longitude: parseFloat(localLongitudeLeft),
+                },
+                bottomRight: {
+                    latitude: parseFloat(localLatitudeBottom),
+                    longitude: parseFloat(localLongitudeRight),
+                },
+            };
+
+            try {
+                const endpoint = '/areasOfInterest';
+                await axios.post(`http://localhost:3001${endpoint}`, newAreaOfInterest);
+                dispatch(addAreaOfInterest(newAreaOfInterest));
+                alert('Nova área adicionada com sucesso!');
+            } catch (error) {
+                console.error('Error adding item:', error);
+            }
+        }
+    };
+
+    return (
+        <div>
+            <h3 className="text-2xl">Adicionar Área de Interesse</h3>
+            <div className="flex justify-start gap-2">
+                <div>
+                    <span>Descrição: </span>
+                    <Input value={localDescription} onChange={(e) => setLocalDescription(e.target.value)} />
+                </div>
+                <div>
+                    <span>Latitude Superior: </span>
+                    <Input value={localLatitudeTop} onChange={(e) => setLocalLatitudeTop(e.target.value)} />
+                </div>
+                <div>
+                    <span>Longitude Esquerda: </span>
+                    <Input value={localLongitudeLeft} onChange={(e) => setLocalLongitudeLeft(e.target.value)} />
+                </div>
+                <div>
+                    <span>Latitude Inferior: </span>
+                    <Input value={localLatitudeBottom} onChange={(e) => setLocalLatitudeBottom(e.target.value)} />
+                </div>
+                <div>
+                    <span>Longitude Inferior: </span>
+                    <Input value={localLongitudeRight} onChange={(e) => setLocalLongitudeRight(e.target.value)} />
+                </div>
+
+                <Button text="Salvar" onClick={handleAddAreaOfInterest} />
+            </div>
+        </div>
+    );
+};
+
+export default AddPointForm;

--- a/src/components/molecules/AddAreaOfInterestButton.tsx
+++ b/src/components/molecules/AddAreaOfInterestButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { setFormType } from '../../redux/slices/formType';
+import { Button } from '../atoms';
+
+const AddAreaOfInterestButton: React.FC = () => {
+    const dispatch = useDispatch();
+
+    const handleAddAreaOfInterest = () => {
+        dispatch(setFormType('AddAreaForm'));
+    };
+
+    return <Button text="Pontos +" onClick={handleAddAreaOfInterest} color="invisible" />;
+};
+
+export default AddAreaOfInterestButton;

--- a/src/components/molecules/AddAreaOfInterestButton.tsx
+++ b/src/components/molecules/AddAreaOfInterestButton.tsx
@@ -10,7 +10,7 @@ const AddAreaOfInterestButton: React.FC = () => {
         dispatch(setFormType('AddAreaForm'));
     };
 
-    return <Button text="Pontos +" onClick={handleAddAreaOfInterest} color="invisible" />;
+    return <Button text="Áreas +" onClick={handleAddAreaOfInterest} color="invisible" />;
 };
 
 export default AddAreaOfInterestButton;

--- a/src/components/molecules/ReturnToInitialButton.tsx
+++ b/src/components/molecules/ReturnToInitialButton.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateCurrentPosition } from '../../redux/slices/currentPosition';

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -2,5 +2,6 @@ import AddNewItem from './AddNewItem';
 import DataFetcher from './DataFetcher';
 import InitialForm from './InitialForm';
 import AddPointForm from './AddPointForm';
+import AddAreaForm from './AddAreaForm';
 
-export { AddNewItem, DataFetcher, InitialForm, AddPointForm };
+export { AddNewItem, DataFetcher, InitialForm, AddPointForm, AddAreaForm };

--- a/src/components/organisms/SideBar.tsx
+++ b/src/components/organisms/SideBar.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef } from 'react';
 import ReturnToInitialButton from '../molecules/ReturnToInitialButton';
 import AddPointOfInterestButton from '../molecules/AddPointOfInterestButton';
+import AddAreaOfInterestButton from '../molecules/AddAreaOfInterestButton';
 const SideBar: React.FC = () => {
     return (
         <div className="flex flex-col items-center justify-center pt-10 gap-6">
@@ -9,6 +9,9 @@ const SideBar: React.FC = () => {
             </div>
             <div>
                 <AddPointOfInterestButton />
+            </div>
+            <div>
+                <AddAreaOfInterestButton />
             </div>
         </div>
     );

--- a/src/components/templates/AppTemplate.tsx
+++ b/src/components/templates/AppTemplate.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useEffect } from 'react';
 import Map from '../organisms/Map';
-import { DataFetcher, InitialForm, AddPointForm } from '../molecules';
+import { DataFetcher, InitialForm, AddPointForm, AddAreaForm } from '../molecules';
 import { useSelector } from 'react-redux';
 import SideBar from '../organisms/SideBar';
-import AddAreaForm from '../molecules/AddAreaForm';
 
 function App() {
     const currentPosition = useSelector((state: any) => state.currentPosition);

--- a/src/components/templates/AppTemplate.tsx
+++ b/src/components/templates/AppTemplate.tsx
@@ -4,6 +4,7 @@ import Map from '../organisms/Map';
 import { DataFetcher, InitialForm, AddPointForm } from '../molecules';
 import { useSelector } from 'react-redux';
 import SideBar from '../organisms/SideBar';
+import AddAreaForm from '../molecules/AddAreaForm';
 
 function App() {
     const currentPosition = useSelector((state: any) => state.currentPosition);
@@ -39,6 +40,7 @@ function App() {
                     <div className="ml-3">
                         {currentForm === 'InitialForm' && <InitialForm />}
                         {currentForm === 'AddPointForm' && <AddPointForm />}
+                        {currentForm === 'AddAreaForm' && <AddAreaForm />}
                     </div>
                     <Map />
                 </main>

--- a/src/db/db.json
+++ b/src/db/db.json
@@ -1,8 +1,8 @@
 {
     "initialPosition": {
-        "latitude": -15.779038580798684,
-        "longitude": -47.75618013453427,
-        "zoomLevel": 10
+        "latitude": -15.78217479876596,
+        "longitude": -47.86369615835108,
+        "zoomLevel": 12
     },
     "pointsOfInterest": [
         {
@@ -125,6 +125,42 @@
             "bottomRight": {
                 "latitude": -15.796712126192793,
                 "longitude": -47.87631337210433
+            }
+        },
+        {
+            "id": 170079244483635,
+            "description": "Brasilia Inteira",
+            "topLeft": {
+                "latitude": -15.708904645849522,
+                "longitude": -47.98220257979214
+            },
+            "bottomRight": {
+                "latitude": -15.8517464011361,
+                "longitude": -47.81182075728044
+            }
+        },
+        {
+            "id": 170079269984398,
+            "description": "Pernambuco",
+            "topLeft": {
+                "latitude": -7.612936028725667,
+                "longitude": -39.1524043081222
+            },
+            "bottomRight": {
+                "latitude": -9.30946403606614,
+                "longitude": -34.96430918702842
+            }
+        },
+        {
+            "id": 170079491056065,
+            "description": "Sobral",
+            "topLeft": {
+                "latitude": -3.587128607531157,
+                "longitude": -40.45445566536668
+            },
+            "bottomRight": {
+                "latitude": -3.7668054463809337,
+                "longitude": -40.24697457505002
             }
         }
     ],

--- a/src/db/db.json
+++ b/src/db/db.json
@@ -1,132 +1,151 @@
 {
-  "initialPosition": {
-    "latitude": -15.779038580798684,
-    "longitude": -47.75618013453427,
-    "zoomLevel": 10
-  },
-  "pointsOfInterest": [
-    {
-      "id": 1700442501594,
-      "description": "Parque Flamboyant Goiânia",
-      "latitude": -16.700423742075337,
-      "longitude": -49.23878754331669,
-      "zoomLevel": 16
+    "initialPosition": {
+        "latitude": -15.779038580798684,
+        "longitude": -47.75618013453427,
+        "zoomLevel": 10
     },
-    {
-      "id": 1700442467379,
-      "description": "Jardim Botânico do Rio de Janeiro",
-      "latitude": -22.97015109742139,
-      "longitude": -43.224454298635614,
-      "zoomLevel": 14
-    },
-    {
-      "id": 1700442424553,
-      "description": "Parque Ecológico de Águas Claras",
-      "latitude": -15.835560879252482,
-      "longitude": -48.0252158841152,
-      "zoomLevel": 14
-    },
-    {
-      "id": 1700498272238,
-      "description": "Parque do Barigui Curitiba",
-      "latitude": -25.425464718145783,
-      "longitude": -49.30800478875754,
-      "zoomLevel": 14
-    },
-    {
-      "id": 170076021072749,
-      "description": "Ponto de interesse",
-      "latitude": -19.476950206488414,
-      "longitude": -48.29481061586706,
-      "zoomLevel": 5
-    },
-    {
-      "id": 170076134504696,
-      "description": "Brazil",
-      "latitude": -14.623697502942658,
-      "longitude": -49.27648624534115,
-      "zoomLevel": 4
-    },
-    {
-      "id": 170076157279014,
-      "description": "Brasília",
-      "latitude": -15.785926187377566,
-      "longitude": -47.876326857866644,
-      "zoomLevel": 12
-    },
-    {
-      "id": 170077095367324,
-      "description": "Testing",
-      "latitude": -13.14581726891326,
-      "longitude": -65.04393747277925,
-      "zoomLevel": 5
-    },
-    {
-      "id": 170077099435285,
-      "description": "Centro de Brasilia",
-      "latitude": -15.793323120787448,
-      "longitude": -47.88262607646629,
-      "zoomLevel": 16
-    },
-    {
-      "id": 170077113968762,
-      "description": "bangui",
-      "latitude": 4.375577685958153,
-      "longitude": 18.557764566081634,
-      "zoomLevel": 12
-    },
-    {
-      "id": 170077285073342,
-      "description": "SP Capital",
-      "latitude": -23.550013946550195,
-      "longitude": -46.6356345647906,
-      "zoomLevel": 11
-    }
-  ],
-  "areasOfInterest": [
-    {
-      "id": 1,
-      "topLeft": {
-        "latitude": 37.7749,
-        "longitude": -122.4194
-      },
-      "bottomRight": {
-        "latitude": 38.7749,
-        "longitude": -121.4194
-      },
-      "description": "Area 1"
-    },
-    {
-      "id": 2,
-      "topLeft": {
-        "latitude": 40.7128,
-        "longitude": -74.006
-      },
-      "bottomRight": {
-        "latitude": 41.7128,
-        "longitude": -73.006
-      },
-      "description": "Area 2"
-    }
-  ],
-  "attentionPerimeters": [
-    {
-      "id": 1,
-      "center": {
-        "latitude": 37.7749,
-        "longitude": -122.4194
-      },
-      "radius": 5000,
-      "description": "Perimeter 1"
-    },
-    {
-      "id": 2,
-      "center": {
-        "latitude": 40.7128,
-        "longitude": -74.006
-      },
-      "radius": 7000,
-      "description": "Perimeter 2"
-    }
-  ]
+    "pointsOfInterest": [
+        {
+            "id": 1700442501594,
+            "description": "Parque Flamboyant Goiânia",
+            "latitude": -16.700423742075337,
+            "longitude": -49.23878754331669,
+            "zoomLevel": 16
+        },
+        {
+            "id": 1700442467379,
+            "description": "Jardim Botânico do Rio de Janeiro",
+            "latitude": -22.97015109742139,
+            "longitude": -43.224454298635614,
+            "zoomLevel": 14
+        },
+        {
+            "id": 1700442424553,
+            "description": "Parque Ecológico de Águas Claras",
+            "latitude": -15.835560879252482,
+            "longitude": -48.0252158841152,
+            "zoomLevel": 14
+        },
+        {
+            "id": 1700498272238,
+            "description": "Parque do Barigui Curitiba",
+            "latitude": -25.425464718145783,
+            "longitude": -49.30800478875754,
+            "zoomLevel": 14
+        },
+        {
+            "id": 170076021072749,
+            "description": "Ponto de interesse",
+            "latitude": -19.476950206488414,
+            "longitude": -48.29481061586706,
+            "zoomLevel": 5
+        },
+        {
+            "id": 170076134504696,
+            "description": "Brazil",
+            "latitude": -14.623697502942658,
+            "longitude": -49.27648624534115,
+            "zoomLevel": 4
+        },
+        {
+            "id": 170076157279014,
+            "description": "Brasília",
+            "latitude": -15.785926187377566,
+            "longitude": -47.876326857866644,
+            "zoomLevel": 12
+        },
+        {
+            "id": 170077095367324,
+            "description": "Testing",
+            "latitude": -13.14581726891326,
+            "longitude": -65.04393747277925,
+            "zoomLevel": 5
+        },
+        {
+            "id": 170077099435285,
+            "description": "Centro de Brasilia",
+            "latitude": -15.793323120787448,
+            "longitude": -47.88262607646629,
+            "zoomLevel": 16
+        },
+        {
+            "id": 170077113968762,
+            "description": "bangui",
+            "latitude": 4.375577685958153,
+            "longitude": 18.557764566081634,
+            "zoomLevel": 12
+        },
+        {
+            "id": 170077285073342,
+            "description": "SP Capital",
+            "latitude": -23.550013946550195,
+            "longitude": -46.6356345647906,
+            "zoomLevel": 11
+        },
+        {
+            "id": 170077737121178,
+            "description": "Aracaju",
+            "latitude": -10.910747939624677,
+            "longitude": -37.06666848538945,
+            "zoomLevel": 14
+        }
+    ],
+    "areasOfInterest": [
+        {
+            "id": 1,
+            "topLeft": {
+                "latitude": 37.7749,
+                "longitude": -122.4194
+            },
+            "bottomRight": {
+                "latitude": 38.7749,
+                "longitude": -121.4194
+            },
+            "description": "Area 1"
+        },
+        {
+            "id": 2,
+            "topLeft": {
+                "latitude": 40.7128,
+                "longitude": -74.006
+            },
+            "bottomRight": {
+                "latitude": 41.7128,
+                "longitude": -73.006
+            },
+            "description": "Area 2"
+        },
+        {
+            "id": 170077943719928,
+            "description": "O ponto Teste",
+            "topLeft": {
+                "latitude": -15.79051280184029,
+                "longitude": -47.88661865490593
+            },
+            "bottomRight": {
+                "latitude": -15.796712126192793,
+                "longitude": -47.87631337210433
+            }
+        }
+    ],
+    "attentionPerimeters": [
+        {
+            "id": 1,
+            "center": {
+                "latitude": 37.7749,
+                "longitude": -122.4194
+            },
+            "radius": 5000,
+            "description": "Perimeter 1"
+        },
+        {
+            "id": 2,
+            "center": {
+                "latitude": 40.7128,
+                "longitude": -74.006
+            },
+            "radius": 7000,
+            "description": "Perimeter 2"
+        }
+    ]
 }

--- a/src/index.css
+++ b/src/index.css
@@ -26,3 +26,19 @@ body {
 code {
     font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+.leaflet-draw-draw-rectangle {
+    width: 5rem !important;
+    height: min-content !important;
+    line-height: 1rem !important;
+    background-color: #104e8b !important;
+    color: #ffffff !important;
+    padding: 0.25rem 0.65rem;
+}
+
+.leaflet-draw-actions a {
+    margin-top: 1rem !important;
+    background-color: #8b1010;
+    color: #ffffff !important;
+    padding: 0.25rem 0.65rem;
+}

--- a/src/redux/slices/areasOfInterest.ts
+++ b/src/redux/slices/areasOfInterest.ts
@@ -1,0 +1,46 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+interface Coordinates {
+    latitude: number;
+    longitude: number;
+}
+
+interface AreaOfInterest {
+    id: number;
+    description: string;
+    topLeft: Coordinates;
+    bottomRight: Coordinates;
+}
+
+interface AreaOfInterestState {
+    areasOfInterest: AreaOfInterest[];
+    selectedAreaOfInterest?: SelectedAreaOfInterestState | null;
+}
+
+type SelectedAreaOfInterestState = {
+    topLeft: Coordinates;
+    bottomRight: Coordinates;
+};
+
+const initialState: AreaOfInterestState = {
+    areasOfInterest: [],
+};
+
+const areasOfInterestSlice = createSlice({
+    name: 'areasOfInterest',
+    initialState,
+    reducers: {
+        setSelectAreaOfInterest: (state, action: PayloadAction<SelectedAreaOfInterestState>) => {
+            state.selectedAreaOfInterest = action.payload;
+        },
+        addAreasOfInterest: (state, action: PayloadAction<AreaOfInterest[]>) => {
+            state.areasOfInterest.push(...action.payload);
+        },
+        addAreaOfInterest: (state, action: PayloadAction<AreaOfInterest>) => {
+            state.areasOfInterest.push(action.payload);
+        },
+    },
+});
+
+export const { addAreaOfInterest, addAreasOfInterest, setSelectAreaOfInterest } = areasOfInterestSlice.actions;
+export default areasOfInterestSlice.reducer;

--- a/src/redux/slices/formType.ts
+++ b/src/redux/slices/formType.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface FormType {
-    currentForm: 'InitialForm' | 'AddPointForm';
+    currentForm: 'InitialForm' | 'AddPointForm' | 'AddAreaForm';
 }
 
 const initialState: FormType = {
@@ -12,7 +12,7 @@ const formTypeSlice = createSlice({
     name: 'formType',
     initialState,
     reducers: {
-        setFormType: (state, action: PayloadAction<'InitialForm' | 'AddPointForm'>) => {
+        setFormType: (state, action: PayloadAction<'InitialForm' | 'AddPointForm' | 'AddAreaForm'>) => {
             state.currentForm = action.payload;
         },
     },

--- a/src/redux/slices/index.ts
+++ b/src/redux/slices/index.ts
@@ -2,12 +2,14 @@ import currentPosition from './currentPosition';
 import formType from './formType';
 import initialPosition from './initialPosition';
 import pointsOfInterest from './pointsOfInterest';
+import areasOfInterest from './areasOfInterest';
 
 const rootReducer = {
     currentPosition,
     formType,
     initialPosition,
     pointsOfInterest,
+    areasOfInterest,
 };
 
 export default rootReducer;


### PR DESCRIPTION
# Áreas de interesse

> Este PR implementa uma nova funcionalidade que permite aos usuários criar áreas de interesse no mapa. As principais características desta implementação incluem:

- **Entrar no modo criar área de interesse**: Foi adicionado um novo botão "Áreas +" na barra lateral. Ao clicar neste botão, o aplicativo entra automaticamente no modo de criação de área de interesse.

- **Desenhar nova área**: No modo de criação de área, os usuários podem desenhar uma nova área diretamente no mapa. Isso é feito através de uma ferramenta de desenho que permite desenhar retângulos.

- **Cancelar o desenho**: Se um usuário decidir cancelar o desenho antes de concluir, há uma opção para cancelar a operação. Isso remove qualquer desenho em andamento e retorna ao estado anterior.

- **Gerenciamento de desenhos anteriores**: Se um usuário iniciar outro desenho sem salvar o anterior, o último desenho é apagado e desconsiderado. Isso garante que apenas a área de interesse mais recente seja considerada.

Este conjunto de funcionalidades oferece uma experiência de usuário intuitiva e flexível para adicionar áreas de interesse, seja por meio de entradas de coordenadas ou desenhando diretamente no mapa.

Testes realizados:
Foram realizados testes extensivos para garantir que a funcionalidade de criação de área de interesse funcione conforme esperado. Isso inclui testes de criação, cancelamento e substituição de desenhos.

Notas adicionais:

> Foi adicionado um ícone "Criar Área" para indicar visualmente o modo de criação de área.
>  estrutura do código foi mantida clara e organizada para facilitar futuras manutenções.

## Este PR visa aprimorar a usabilidade do aplicativo, permitindo que os usuários adicionem áreas de interesse de maneira intuitiva. Qualquer feedback adicional é bem-vindo!

https://github.com/GabFiterman/leaflet-zen/assets/94033226/50170d0b-f25d-4334-9353-fb82da9fcfe2
